### PR TITLE
Allow dependency on new Asciidoctor versions 1.x

### DIFF
--- a/nanoc-asciidoctor.gemspec
+++ b/nanoc-asciidoctor.gemspec
@@ -25,6 +25,6 @@ Gem::Specification.new do |s|
   s.extra_rdoc_files = [ 'LICENSE', 'README.md', 'NEWS.md' ]
 
   s.add_runtime_dependency('nanoc', '>= 3.6.7', '< 4.0.0')
-  s.add_runtime_dependency('asciidoctor', '~> 0.1')
+  s.add_runtime_dependency('asciidoctor', '> 0.1', '< 2.0')
   s.add_development_dependency('bundler', '~> 1.5')
 end


### PR DESCRIPTION
The latest Asciidoctor release jumped a major version number, but still uses the same `Asciidoctor.render()` API call.
