### PR TITLE
Support Nanoc 4

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # nanoc-asciidoctor news
 
+## 1.0.2
+
+* Added support for Nanoc 4.x
+
 ## 1.0.1
 
 * Added support for Asciidoctor 1.x

--- a/README.md
+++ b/README.md
@@ -12,8 +12,18 @@ This provides a filter for [Asciidoctor](http://asciidoctor.org/), a Ruby proces
 
 ## Usage
 
+On the `Rules` file, require the library, and call as you prefer:
+
 ```ruby
-filter :asciidoctor
+require 'nanoc-asciidoctor'
+
+compile '/**/*.adoc' do
+  filter :asciidoctor
+  layout '/default.*'
+  # Or wrap the markup in full HTML through AsciiDoctor
+  # filter :asciidoctor, :header_footer => true
+end
+
 ```
 
 Options passed to this filter will be passed on to `Asciidoctor.render`.

--- a/lib/nanoc/asciidoctor/version.rb
+++ b/lib/nanoc/asciidoctor/version.rb
@@ -3,7 +3,7 @@
 module Nanoc
   module Asciidoctor
 
-    VERSION = '1.0.1'
+    VERSION = '1.0.2'
 
   end
 end

--- a/nanoc-asciidoctor.gemspec
+++ b/nanoc-asciidoctor.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.rdoc_options     = [ '--main', 'README.md' ]
   s.extra_rdoc_files = [ 'LICENSE', 'README.md', 'NEWS.md' ]
 
-  s.add_runtime_dependency('nanoc', '>= 3.6.7', '< 4.0.0')
+  s.add_runtime_dependency('nanoc', '>= 3.6.7', '< 5.0.0')
   s.add_runtime_dependency('asciidoctor', '> 0.1', '< 2.0')
   s.add_development_dependency('bundler', '~> 1.5')
 end


### PR DESCRIPTION
- No changes needed to the filter, just upgrade the gemspec dependency.
- Update release notes.
- Update docs with usage notes.